### PR TITLE
A fix to invalid commands causing node-telnet to crash irrevocably.

### DIFF
--- a/lib/telnet.js
+++ b/lib/telnet.js
@@ -7,6 +7,8 @@
  *  - http://support.microsoft.com/kb/231866
  *  - http://www.iana.org/assignments/telnet-options
  *
+ *	Revisions:
+ *		2015-02-25	Darron Smith (darron@xara.com) - Added guard code to fix the problem with crashing on invalid commands.
  */
 
 // export the "telnet" convenience function directly
@@ -146,10 +148,17 @@ function parse(bufs) {
   return parseCommand(bufs, 1, {})
 }
 
+
 function parseCommand (bufs, i, event) {
   var command = bufs.get(i)
   event.commandCode = command
   event.command = COMMAND_NAMES[command]
+  if (typeof COMMAND_IMPLS[command] !== 'function') {
+		event.buf = bufs.splice(0, i + 1).toBuffer();
+		event.commandCode = null;
+		event.command = null;
+		return event;
+  }
   return COMMAND_IMPLS[command](bufs, i + 1, event)
 }
 
@@ -157,9 +166,14 @@ function parseOption (bufs, i, event) {
   var option = bufs.get(i)
   event.optionCode = option
   event.option = OPTION_NAMES[option]
+  if (typeof OPTION_IMPLS[option] !== 'function') {
+		event.buf = bufs.splice(0, i + 1).toBuffer();
+		event.optionCode = null;
+		event.option = null;
+		return event;
+  }
   return OPTION_IMPLS[option](bufs, i + 1, event)
 }
-
 
 function Socket (input, output) {
   Stream.call(this)
@@ -204,8 +218,10 @@ function Socket (input, output) {
         break
       } else {
         debug('emitting event', i)
-        self.emit('event', i)
-        self.emit(i.command, i)
+        if (i.command) {
+			self.emit('event', i)
+			self.emit(i.command, i)
+		}
         if (i.option) {
           self.emit(i.option, i)
         }


### PR DESCRIPTION
I've been waiting for a few months for a fix to this so I did it myself. OK, try/catch could have been used but it seemed a cleaner solution to put in guard code where the crash is happening and just ignore the command code or option code entirely.