### PR TITLE
update telnet.js so it doesn't crash on control key sends, since linemod...

### DIFF
--- a/lib/telnet.js
+++ b/lib/telnet.js
@@ -20,22 +20,25 @@ var net = require('net')
   , Binary = require('binary')
 
 var COMMANDS = {
-    SE:   240 // end of subnegotiation parameters
-  , NOP:  241 // no operation
-  , DM:   242 // data mark
-  , BRK:  243 // break
-  , IP:   244 // suspend (a.k.a. "interrupt process")
-  , AO:   245 // abort output
-  , AYT:  246 // are you there?
-  , EC:   247 // erase character
-  , EL:   248 // erase line
-  , GA:   249 // go ahead
-  , SB:   250 // subnegotiation
-  , WILL: 251 // will
-  , WONT: 252 // wont
-  , DO:   253 // do
-  , DONT: 254 // dont
-  , IAC:  255 // interpret as command
+      EOF:   236 // Actual EOF character where supported. [ignoring]
+    , SUSP:  237 // Request a suspend. [ignoring]
+    , ABORT: 238 // Request an abort. [ignoring]
+    , SE:    240 // end of subnegotiation parameters
+    , NOP:   241 // no operation
+    , DM:    242 // data mark
+    , BRK:   243 // break
+    , IP:    244 // suspend (a.k.a. "interrupt process")
+    , AO:    245 // abort output
+    , AYT:   246 // are you there?
+    , EC:    247 // erase character
+    , EL:    248 // erase line
+    , GA:    249 // go ahead
+    , SB:    250 // subnegotiation
+    , WILL:  251 // will
+    , WONT:  252 // wont
+    , DO:    253 // do
+    , DONT:  254 // dont
+    , IAC:   255 // interpret as command
 }
 
 var OPTIONS = {
@@ -89,6 +92,15 @@ COMMAND_IMPLS[COMMANDS.IAC] = function (bufs, i, event) {
   return event
 }
 
+;['eof','susp','abort','ec','el'].forEach(function (command) {
+    var code = COMMANDS[command.toUpperCase()]
+    COMMAND_IMPLS[code] = function (bufs, i, event) {
+        // Needs to be converted to a NOP, we don't want to act on it.
+        event.buf = bufs.splice(0, i).toBuffer()
+        event.data = Buffer([ 241 ])
+        return event
+    }
+})
 
 var OPTION_IMPLS = {}
 // these ones don't take any arguments


### PR DESCRIPTION
Update telnet.js so it doesn't crash on control key sends, since linemode TRAPSIG is not implemented.

This implementation begins the work of adding the additional support, instead of swallowing the errors. It's still not perfect, but a start for users who don't want crashes.